### PR TITLE
Fix issue #10

### DIFF
--- a/lib/watcher.coffee
+++ b/lib/watcher.coffee
@@ -100,8 +100,6 @@ class Watcher extends EventEmitter2
       @destroyErrors()
       @cachedText = text
       @ripper.parse text, @onParseEnd
-    else
-      @onParseEnd()
     @eventCursorMoved = on
 
   onParseEnd: (errors) =>


### PR DESCRIPTION
This "onParseEnd" call seems to be unnecessary, and in case of "parse" being called more than once in a row, causes new reference markers to be created without destroying exiting ones (but losing references to them), which results in issue #10. It seems there are some deeper problems with this code, so it's not really a proper fix, but removing these lines seems to solve the problem without introducing any side effects.
