### PR TITLE
Avoid throwing an error when deactivating package

### DIFF
--- a/lib/refactor.coffee
+++ b/lib/refactor.coffee
@@ -1,13 +1,11 @@
 Watcher = require './watcher'
 ModuleManager = require './module_manager'
+{ CompositeDisposable } = require 'atom'
 { packages: packageManager } = atom
 d = (require 'debug/browser') 'refactor'
 
 module.exports =
 new class Main
-
-  renameCommand: 'refactor:rename'
-  doneCommand: 'refactor:done'
 
   config:
     highlightError:
@@ -25,11 +23,12 @@ new class Main
   activate: (state) ->
     d 'activate'
     @moduleManager = new ModuleManager
+    @disposables = new CompositeDisposable
     @watchers = []
 
-    atom.workspace.observeTextEditors @onCreated
-    atom.commands.add 'atom-text-editor', @renameCommand, @onRename
-    atom.commands.add 'atom-text-editor', @doneCommand, @onDone
+    @disposables.add atom.workspace.observeTextEditors @onCreated
+    @disposables.add atom.commands.add 'atom-text-editor', 'refactor:rename', @onRename
+    @disposables.add atom.commands.add 'atom-text-editor', 'refactor:done', @onDone
 
   deactivate: ->
     @moduleManager.destruct()
@@ -38,8 +37,8 @@ new class Main
       watcher.destruct()
     delete @watchers
 
-    atom.workspaceView.off @renameCommand, @onRename
-    atom.workspaceView.off @doneCommand, @onDone
+    @disposables.dispose()
+    @disposables = null
 
   serialize: ->
 


### PR DESCRIPTION
While investigating an issue with [icon loading](https://github.com/DanBrooker/file-icons/issues/423), I noticed this flash in my console very briefly when reloading the window:

<img src="https://cloud.githubusercontent.com/assets/2346707/19018264/755aa0f0-88a6-11e6-8a1c-a36c6cdfae8e.png" width="558" alt="Figure 1" />

I can't confirm if this is what's causing the sporadic failures reported in #16, but I _do_ know that Atom loads packages synchronously... which means it's subject to race conditions. So if an error occurred while deactivating every package whilst updating, it could interfere with the reactivation of every other package.

That's my theory at least. Even if it doesn't solve this stupid issue, you should at least know you're using a property that was [deprecated over two years ago](https://discuss.atom.io/t/replacement-for-atom-workspaceview-command/13636).
